### PR TITLE
Create output folder recursively

### DIFF
--- a/CrackQL.py
+++ b/CrackQL.py
@@ -206,7 +206,7 @@ def main():
 				directory = 'results/' + urlparse(options.url).netloc + '_' + str(uuid.uuid4())[0:6]
 			print('[*] Writing to directory', directory)
 			if not os.path.exists(directory):
-				os.mkdir(directory)
+				os.makedirs(directory, exist_ok=True)
 
 			if raw_data:
 				f = open(directory + '/data.json', 'w')

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.0'
+VERSION = '1.0.2'


### PR DESCRIPTION
Output folder does not exist by default, so `os.mkdir` fails creating subdirectories there. 
