### PR TITLE
Handle error

### DIFF
--- a/lib/parser.py
+++ b/lib/parser.py
@@ -94,8 +94,9 @@ def parse_error_response(response, raw_errors, error_results, inputs, verbose=Fa
 
 				try:
 					alias = r.get('path')[0]
-				except IndexError:
+				except:
 					alias = 'undefined'
+
 
 				error_result[alias] = {}
 				error_result[alias]['inputs'] = inputs

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.4'
+VERSION = '1.0.5'


### PR DESCRIPTION
Try except on IndexError prevents all errors from being printed to the json result file. We want all of them