### PR TITLE
Fix data output + Optimize parse_data_response() function

### DIFF
--- a/CrackQL.py
+++ b/CrackQL.py
@@ -6,6 +6,7 @@ import time
 import jinja2
 import graphql
 import uuid
+import json
 
 from optparse import OptionParser
 from version import VERSION
@@ -166,9 +167,8 @@ def main():
 
 					for a in definition.selection_set.selections:
 						suffix += 1
-						aliased_field = 'alias' + str(suffix)
 						a.alias = graphql.language.ast.NameNode()
-						a.alias.value = aliased_field
+						a.alias.value = 'alias' + str(suffix)
 
 					batch_operations = batch_operations +'\n'+ get_operation(print_ast(ast))
 
@@ -210,7 +210,7 @@ def main():
 
 			if raw_data:
 				f = open(directory + '/data.json', 'w')
-				f.write(str(raw_data))
+				json.dump(data_results, f)
 				f.close()
 
 			if raw_errors:

--- a/lib/parser.py
+++ b/lib/parser.py
@@ -1,6 +1,7 @@
 import re
 import csv
 import textwrap
+import json
 
 try:
     import textwrap
@@ -68,20 +69,28 @@ def parse_data_response(response, raw_data, data_results, inputs, verbose=False,
 	data_result = {}
 
 	try:
-		if 'data' in response and isinstance(response['data'], dict):
-			raw_data.append(response['data'])
-			count = 0
-			for r in response['data'].items():
-				name, data = r
-				data_result[name] = {}
-				if variables_list:
-					data_result[name]['inputs'] = variables_list[count]
-				else:
-					data_result[name]['inputs'] = inputs
-				data_result[name]['data'] = data
+		data = response.get('data')
+		if isinstance(data, dict):
+			raw_data.append(data)
+
+			for count, (name, data_value) in enumerate(data.items()):
+				current_input = variables_list[count] if variables_list else inputs
+				data_result = {
+					name: {
+						'inputs': current_input,
+						'data': data_value
+					}
+				}
 				data_results.append(data_result)
-				data_result = {}
-				count += 1
+
+	except Exception as e:
+		print(e)
+
+	# Edit the random key by a same key (result)
+	try:
+		for key in data_results:
+			key["result"] = key.pop(next(iter(key)))
+
 	except Exception as e:
 		print(e)
 


### PR DESCRIPTION
Hey @nicholasaleks,

I had the opportunity to use your tool to perform a `batch attack on GraphQL`.
The problem I encountered is that the output of the tool is not JSON parsable.

It looks like :

```json
[{'alias1': {'token': '4sqhWgZS2EGY3eS1vLX5JfpmnRgT52I5', 'success': False}, 'alias2':
[...TRUNCATED DATA...]
```

`Single quotes` don't work with JSON and the keys are different which makes it difficult to parse with tools like `jq`.

So I made changes with [@Cavonstavant](https://github.com/Cavonstavant) to the code to obtain an output with :

* A JSON that can easily be parsed with `jq`
* A change of **"alias..."** keys with a unique **"result"** key
* The variables used in the HTTP request in order to know the correct payload without looking for the correct offset in the CSV file.

Here is an overview :

<img width="941" alt="image" src="https://github.com/nicholasaleks/CrackQL/assets/51704860/36d8a74e-4757-4e5a-9fcd-21ff1fd025dc">

<img width="950" alt="image" src="https://github.com/nicholasaleks/CrackQL/assets/51704860/9f07d84b-23ee-48e8-9c5c-fd9248b3fcb9">

<img width="1376" alt="image" src="https://github.com/nicholasaleks/CrackQL/assets/51704860/0f4e0471-4803-4ba6-a6f0-ce6de2481325">

**Note :** The `parse_data_response()` function has been optimized.